### PR TITLE
func to get raw token

### DIFF
--- a/authentication.context.spec.ts
+++ b/authentication.context.spec.ts
@@ -150,4 +150,14 @@ describe('AuthenticationContext', () => {
         expect(this.navigator.navigate).toHaveBeenCalledWith('http://microsoft.com');
     });
 
+    it('getToken should call localStorage once', () => {
+        spyOn(this.localStorage, 'getItem');
+        this.sut.getToken();
+        expect(this.localStorage.getItem).toHaveBeenCalledWith(Constants.STORAGE.IDTOKEN);
+        expect(this.localStorage.getItem).toHaveBeenCalledTimes(1);
+    })
+        
+    
+    
+
 });

--- a/authentication.context.ts
+++ b/authentication.context.ts
@@ -71,6 +71,10 @@ export class AuthenticationContext {
         }
     }
 
+    public getToken(): string {
+        return this.storage.getItem(Constants.STORAGE.IDTOKEN);
+    }
+
     public logout(): void {
         let idtoken = this.storage.getItem(Constants.STORAGE.IDTOKEN);
         if (idtoken === '') return null;


### PR DESCRIPTION
It is currently only possible to get a passed token from the context. This addition allows for correct retrieval of the raw token through the context for use eg. in Authentication header against a web api.