### PR TITLE
fix: minor typo in error message

### DIFF
--- a/src/user.decoder.ts
+++ b/src/user.decoder.ts
@@ -36,7 +36,7 @@ export class UserDecoder {
 
         var matches = idTokenPartsRegex.exec(jwtToken);
         if (!matches || matches.length < 4) {
-            throw new Error(`Failed to decode Jwt token. The token has in valid format. Actual token: '${jwtToken}'`);
+            throw new Error(`Failed to decode Jwt token. The token has invalid format. Actual token: '${jwtToken}'`);
         }
 
         var crackedToken = {


### PR DESCRIPTION
Using `in valid` instead of `invalid`.