### PR TITLE
fix: failing build due to no tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 *.js
 !webpack.config.js
 !karma.conf.js
+!karma.specs.js
 *.map
 *.d.ts
 .idea/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,14 +7,14 @@ module.exports = function (config) {
         // list of files / patterns to load in the browser
         files: [
             //{ pattern: 'dist/*.js', included: true },
-            { pattern: '*.spec.ts', watched: true }
+            { pattern: './karma.specs.js', watched: true }
         ],
 
         // list of files / patterns to exclude
         exclude: [],
 
         preprocessors: {
-            '*.spec.ts': ['webpack', 'sourcemap'],
+            './karma.specs.js': ['webpack', 'sourcemap'],
             //'*.ts': ['webpack', 'sourcemap', 'coverage'],
             //'**/!(*.spec)+(.js)': ['coverage']
             //'**/*.js': ['coverage']

--- a/karma.specs.js
+++ b/karma.specs.js
@@ -1,0 +1,3 @@
+var testsContext = require.context('./src', true, /\.spec\.ts/);
+
+testsContext.keys().forEach(testsContext);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "reflect-metadata": "0.1.8",
     "rxjs": "5.0.0-beta.12",
     "ts-loader": "^1.3.3",
-    "typescript": "^2.0.10",
+    "typescript": "2.0.10",
     "webpack": "^1.13.0"
   },
   "peerDependencies": {}


### PR DESCRIPTION
Travis seems to fail on new builds: https://travis-ci.org/HNeukermans/adal-ts/jobs/184817620

```
17 12 2016 19:37:28.799:WARN [watcher]: Pattern "/home/travis/build/HNeukermans/adal-ts/*.spec.ts" does not match any file.
17 12 2016 19:37:28.804:WARN [watcher]: Pattern "/home/travis/build/HNeukermans/adal-ts/*.spec.ts" does not match any file.
17 12 2016 19:37:28.832:INFO [karma]: Karma v1.3.0 server started at http://localhost:9876/
17 12 2016 19:37:28.832:INFO [launcher]: Launching browser Chrome with unlimited concurrency
17 12 2016 19:37:28.840:INFO [launcher]: Starting browser Chrome
17 12 2016 19:37:30.891:INFO [Chromium 37.0.2062 (Ubuntu 0.0.0)]: Connected on socket /#6CekorrepbnYU8sGAAAA with id 2759752
Chromium 37.0.2062 (Ubuntu 0.0.0): Executed 0 of 0 SUCCESS (0 secs / 0 secs)
ium 37.0.2062 (Ubuntu 0.0.0): Executed 0 of 0 ERROR (0.002 secs / 0 secs)
Chromium 37.0.2062 (Ubuntu 0.0.0): Executed 0 of 0 ERROR (0.002 secs / 0 secs)
npm ERR! Test failed.  See above for more details.
```

After cloning the repository locally I stumbled upon the following error in `awesome-typescript-loader`:

> Cannot read property 'exclude' of undefined 

More info: 
- https://github.com/s-panferov/awesome-typescript-loader/issues/190
- https://github.com/s-panferov/awesome-typescript-loader/issues/293

Basicly I locked down the TS version to the one specified in `package.json` (2.0.10). If you want I can update the PR to target TypeScript 2.1.1 or even go with a beta of awesome typescript loader (`^3.0.0-beta.9`) and use TypeScript 2.1.4.

Apart from that I also changed the way karma looks for the tests, as described in https://webpack.github.io/docs/usage-with-karma.html.

Without changing it karma didn't want to find any `spec` file. But I'm guessing there's something wrong with webpack versioning in `package.json`.
The `package.json` files requires `"webpack": "^1.13.0"` and `"awesome-typescript-loader": "^2.2.4",`. But the docs of `awesome-typescript-loader` clearly states: 

> awesome-typescript-loader@2.x aims to support only typescript@2.x and webpack@2x, if you need old compilers please use 1.x or 0.x versions.

More info: https://github.com/s-panferov/awesome-typescript-loader

Changing the way karma looks for the spec files was the easiest fix. However, i'd like to undo this change and update to webpack 2. But I wanted to create this PR in order to also discuss this webpack version thing/issue.

What webpack version is the project supposed to be using? 
