### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ let user = context.getUser();
 ```
 let config = new AdalConfig('clientID', 'unittest.onmicrosoft.com', 'http://localhost');
 let context = Authentication.getContext(config);
-let user = context.logout();
+context.logout();
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ Pull requests are welcome!
 
 ## Building
 
-Use `webpack` cmd to compile and build. A /dist folder is generated.
+Use `webpack` to compile and build. A `/dist` folder is generated.
+
+```
+npm run webpack
+```
 
 ## Code coverage
 


### PR DESCRIPTION
- Once https://github.com/HNeukermans/adal-ts/pull/18 gets merged, the webpack cmd is available using `npm run webpack`.
So I've add webpack scripts to readme.

- The `logout` method does not return anything, but the readme states otherwise:
```
let config = new AdalConfig('clientID', 'unittest.onmicrosoft.com', 'http://localhost');
let context = Authentication.getContext(config);
let user = context.logout();
```