### PR TITLE
fix: replace npm start with npm run build for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3
-  - npm start &
+  - npm run build &
   - sleep 5
 script:
   - npm test


### PR DESCRIPTION
This should fix https://github.com/HNeukermans/adal-ts/issues/20

However, shouldn't webpack we used instead of tsc ?